### PR TITLE
Adding opportunity of choosing the size of the worker

### DIFF
--- a/nodes.tf
+++ b/nodes.tf
@@ -6,7 +6,7 @@ resource "scaleway_server" "k8s_node" {
   count     = "${var.nodes}"
   name      = "${terraform.workspace}-node-${count.index + 1}"
   image     = "${data.scaleway_image.xenial.id}"
-  type      = "${var.server_type}"
+  type      = "${var.server_type_node}"
   public_ip = "${element(scaleway_ip.k8s_node_ip.*.ip, count.index)}"
 
   //  volume {

--- a/variables.tf
+++ b/variables.tf
@@ -18,9 +18,15 @@ variable "arch" {
 
 variable "region" {
   default = "par1"
+  description = "Values: par1 ams1"
 }
 
 variable "server_type" {
+  default     = "C1"
+  description = "Use C1 for arm, ARM64-2GB for arm64 and C2S for x86_64"
+}
+
+variable "server_type_node" {
   default     = "C1"
   description = "Use C1 for arm, ARM64-2GB for arm64 and C2S for x86_64"
 }


### PR DESCRIPTION
Issue #6 
- Add a new `server_type_node` variable to give a different instance size for workers,
- Add a new description for the `region` variable.