### PR TITLE
Adding the possibility of choosing the size of the worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ terraform apply \
  -var arch=arm \
  -var server_type=C1 \
  -var nodes=2 \
+ -var server_type_node=C1 \
  -var weave_passwd=ChangeMe \
  -var k8s_version=stable-1.9 \
  -var docker_version=17.03.0~ce-0~ubuntu-xenial
@@ -42,7 +43,7 @@ $ terraform apply \
 This will do the following:
 
 * reserves public IPs for each server
-* provisions three bare-metal servers with Ubuntu 16.04.1 LTS
+* provisions three bare-metal servers with Ubuntu 16.04.1 LTS (the size of the `master` and the `worker` may be different but must remain in the same type of architecture)
 * connects to the master server via SSH and installs Docker CE and kubeadm armhf apt packages
 * runs kubeadm init on the master server and configures kubectl
 * downloads the kubectl admin config file on your local machine and replaces the private IP with the public one
@@ -56,7 +57,7 @@ Scale up by increasing the number of nodes:
 
 ```bash
 $ terraform apply \
- -var nodes=3 
+ -var nodes=3
 ```
 
 Tear down the whole infrastructure with:
@@ -73,8 +74,9 @@ $ terraform workspace new amd64
 $ terraform apply \
  -var region=par1 \
  -var arch=x86_64 \
- -var server_type=C2S \
+ -var server_type=C2M \
  -var nodes=1 \
+ -var server_type_node=C2S \
  -var weave_passwd=ChangeMe \
  -var k8s_version=stable-1.9 \
  -var docker_version=17.03.0~ce-0~ubuntu-xenial

--- a/nodes.tf
+++ b/nodes.tf
@@ -6,7 +6,7 @@ resource "scaleway_server" "k8s_node" {
   count     = "${var.nodes}"
   name      = "${terraform.workspace}-node-${count.index + 1}"
   image     = "${data.scaleway_image.xenial.id}"
-  type      = "${var.server_type}"
+  type      = "${var.server_type_node}"
   public_ip = "${element(scaleway_ip.k8s_node_ip.*.ip, count.index)}"
 
   //  volume {

--- a/variables.tf
+++ b/variables.tf
@@ -18,9 +18,15 @@ variable "arch" {
 
 variable "region" {
   default = "par1"
+  description = "Values: par1 ams1"
 }
 
 variable "server_type" {
+  default     = "C1"
+  description = "Use C1 for arm, ARM64-2GB for arm64 and C2S for x86_64"
+}
+
+variable "server_type_node" {
   default     = "C1"
   description = "Use C1 for arm, ARM64-2GB for arm64 and C2S for x86_64"
 }


### PR DESCRIPTION
Issue #6 
- Add a new `server_type_node` variable to give a different instance size for workers,
- Add a new description for the `region` variable,
- Update README.md.