### PR TITLE
suggestion to put the hpa describe command into a watch loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ hey -n 10000 -q 10 -c 5 http://$(terraform output k8s_master_public_ip):31190
 You can monitor the autoscaler events with:
 
 ```bash
-$ kubectl --kubeconfig ./$(terraform output kubectl_config) describe hpa
+$ watch -n 5 kubectl --kubeconfig ./$(terraform output kubectl_config) describe hpa
 
 Events:
   Type    Reason             Age   From                       Message


### PR DESCRIPTION
*Issue:*

One needs to keep re-entering the command
```shell
kubectl --kubeconfig ./$(terraform output kubectl_config) describe hpa
```
as time passes.

*Suggestion:*

Add a while loop and reiterate the command to keep a realtime feed
of what is happening in the horizontal scaler.