### PR TITLE
handle SSH key files

### DIFF
--- a/master.tf
+++ b/master.tf
@@ -41,7 +41,7 @@ resource "scaleway_server" "k8s_master" {
     ]
   }
   provisioner "local-exec" {
-    command    = "./scripts/kubectl-conf.sh ${terraform.workspace} ${self.public_ip} ${self.private_ip}"
+    command    = "./scripts/kubectl-conf.sh ${terraform.workspace} ${self.public_ip} ${self.private_ip} ${var.private_key}"
     on_failure = "continue"
   }
 }
@@ -51,6 +51,7 @@ data "external" "kubeadm_join" {
 
   query = {
     host = "${scaleway_ip.k8s_master_ip.0.ip}"
+    key = "${var.private_key}"
   }
 
   depends_on = ["scaleway_server.k8s_master"]

--- a/scripts/kubeadm-token.sh
+++ b/scripts/kubeadm-token.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-# Extract "host" argument from the input into HOST shell variable
-eval "$(jq -r '@sh "HOST=\(.host)"')"
+# Extract "host" and "key_file" argument from the input into HOST shell variable
+eval "$(jq -r '@sh "HOST=\(.host) KEY=\(.key)"')"
 
 # Fetch the join command
-CMD=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+CMD=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $KEY \
     root@$HOST kubeadm token create --print-join-command)
 
 # Produce a JSON object containing the join command

--- a/scripts/kubectl-conf.sh
+++ b/scripts/kubectl-conf.sh
@@ -5,7 +5,8 @@ set -e
 WORKSPACE=$1
 PUBLIC_IP=$2
 PRIVATE_IP=$3
+KEY_FILE=$4
 
-scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@${PUBLIC_IP}:/etc/kubernetes/admin.conf .
+scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${KEY_FILE} root@${PUBLIC_IP}:/etc/kubernetes/admin.conf .
 sed -e "s/${PRIVATE_IP}/${PUBLIC_IP}/g" admin.conf > ${WORKSPACE}.conf
 rm admin.conf


### PR DESCRIPTION
Explicitly sets the `-i` flag for `scp` and `ssh` commands to handle non-default SSH keys.  Fixes #31.