### PR TITLE
Kubernetes 1.12 enhancements for ARM

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ $ terraform apply \
  -var region=par1 \
  -var arch=arm \
  -var server_type=C1 \
- -var nodes=1 \
+ -var nodes=2 \
  -var server_type_node=C1 \
  -var weave_passwd=ChangeMe \
  -var docker_version=17.03.0~ce-0~ubuntu-xenial

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 provider "scaleway" {
   region  = "${var.region}"
-  version = "1.5.1"
+  version = "1.8.0"
 }
 
 provider "external" {

--- a/master.tf
+++ b/master.tf
@@ -30,14 +30,39 @@ resource "scaleway_server" "k8s_master" {
   }
   provisioner "remote-exec" {
     inline = [
-      "set -e",
-      "chmod +x /tmp/docker-install.sh && /tmp/docker-install.sh ${var.docker_version}",
-      "chmod +x /tmp/kubeadm-install.sh && /tmp/kubeadm-install.sh ${var.k8s_version}",
-      "kubeadm init --apiserver-advertise-address=${self.private_ip} --apiserver-cert-extra-sans=${self.public_ip} --kubernetes-version=${var.k8s_version} --ignore-preflight-errors=KubeletVersion",
-      "mkdir -p $HOME/.kube && cp -i /etc/kubernetes/admin.conf $HOME/.kube/config",
-      "kubectl create secret -n kube-system generic weave-passwd --from-literal=weave-passwd=${var.weave_passwd}",
-      "kubectl apply -f \"https://cloud.weave.works/k8s/net?password-secret=weave-passwd&k8s-version=$(kubectl version | base64 | tr -d '\n')\"",
-      "chmod +x /tmp/monitoring-install.sh && /tmp/monitoring-install.sh ${var.arch}",
+      <<EOT
+#!/bin/bash
+set -e
+chmod +x /tmp/docker-install.sh
+chmod +x /tmp/kubeadm-install.sh
+chmod g+w -R /tmp/kubeadm/
+
+/tmp/docker-install.sh ${var.docker_version} && \
+/tmp/kubeadm-install.sh ${var.k8s_version}
+
+modify_kube_apiserver_config(){
+  while [[ ! -e /etc/kubernetes/manifests/kube-apiserver.yaml ]]; do
+    sleep 0.5s;
+  done && \
+  sed -i 's/failureThreshold: [0-9]/failureThreshold: 12/g' /etc/kubernetes/manifests/kube-apiserver.yaml && \
+  sed -i 's/timeoutSeconds: [0-9][0-9]/timeoutSeconds: 20/g' /etc/kubernetes/manifests/kube-apiserver.yaml && \
+  sed -i 's/initialDelaySeconds: [0-9][0-9]/initialDelaySeconds: 120/g' /etc/kubernetes/manifests/kube-apiserver.yaml
+}
+
+# ref https://github.com/kubernetes/kubeadm/issues/413 (initialDelaySeconds is too eager)
+if [[ ${var.arch} == "arm" ]]; then modify_kube_apiserver_config & fi
+
+kubeadm init \
+  --apiserver-advertise-address=${self.private_ip} \
+  --apiserver-cert-extra-sans=${self.public_ip} \
+  --kubernetes-version=${var.k8s_version} \
+  --ignore-preflight-errors=KubeletVersion
+
+mkdir -p $HOME/.kube && cp -i /etc/kubernetes/admin.conf $HOME/.kube/config && \
+kubectl create secret -n kube-system generic weave-passwd --from-literal=weave-passwd=${var.weave_passwd} && \
+kubectl apply -f "https://cloud.weave.works/k8s/net?password-secret=weave-passwd&k8s-version=$(kubectl version | base64 | tr -d '\n')" && \
+chmod +x /tmp/monitoring-install.sh && /tmp/monitoring-install.sh ${var.arch}
+EOT
     ]
   }
   provisioner "local-exec" {

--- a/master.tf
+++ b/master.tf
@@ -35,7 +35,6 @@ resource "scaleway_server" "k8s_master" {
 set -e
 chmod +x /tmp/docker-install.sh
 chmod +x /tmp/kubeadm-install.sh
-chmod g+w -R /tmp/kubeadm/
 
 /tmp/docker-install.sh ${var.docker_version} && \
 /tmp/kubeadm-install.sh ${var.k8s_version}

--- a/master.tf
+++ b/master.tf
@@ -43,9 +43,9 @@ modify_kube_apiserver_config(){
   while [[ ! -e /etc/kubernetes/manifests/kube-apiserver.yaml ]]; do
     sleep 0.5s;
   done && \
-  sed -i 's/failureThreshold: [0-9]/failureThreshold: 12/g' /etc/kubernetes/manifests/kube-apiserver.yaml && \
+  sed -i 's/failureThreshold: [0-9]/failureThreshold: 18/g' /etc/kubernetes/manifests/kube-apiserver.yaml && \
   sed -i 's/timeoutSeconds: [0-9][0-9]/timeoutSeconds: 20/g' /etc/kubernetes/manifests/kube-apiserver.yaml && \
-  sed -i 's/initialDelaySeconds: [0-9][0-9]/initialDelaySeconds: 120/g' /etc/kubernetes/manifests/kube-apiserver.yaml
+  sed -i 's/initialDelaySeconds: [0-9][0-9]/initialDelaySeconds: 240/g' /etc/kubernetes/manifests/kube-apiserver.yaml
 }
 
 # ref https://github.com/kubernetes/kubeadm/issues/413 (initialDelaySeconds is too eager)

--- a/scripts/monitoring-install.sh
+++ b/scripts/monitoring-install.sh
@@ -9,7 +9,9 @@ kubectl apply -f /tmp/heapster-rbac.yaml
 kubectl apply -f /tmp/metrics-server-rbac.yaml
 
 if [ "$ARCH" == "arm" ]; then
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/alternative/kubernetes-dashboard-arm.yaml;
+    curl -s https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/alternative/kubernetes-dashboard-arm.yaml | \
+    sed -e 's/v2.0.0-alpha0/v1.8.3/g' | \
+    kubectl apply -f -;
     kubectl apply -f /tmp/heapster-arm.yaml;
     kubectl apply -f /tmp/metrics-server-arm.yaml;
 elif [ "$ARCH" == "x86_64" ]; then

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "<= 0.11.9"
+  required_version = "<= 0.11.11"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,9 @@ variable "private_key" {
   default     = "~/.ssh/id_rsa"
   description = "The path to your private key"
 }
+
+variable "kubeadm_verbosity" {
+  default     = "0"
+  description = "The verbosity level of the kubeadm init logs"
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "docker_version" {
 }
 
 variable "k8s_version" {
-  default = "stable-1.11"
+  default = "stable-1.12"
 }
 
 variable "weave_passwd" {


### PR DESCRIPTION
#### What does this PR do ?

- Fix for arm where initialDelaySeconds is too eager [ref commit](https://github.com/stefanprodan/k8s-scw-baremetal/pull/38/commits/692eef529e28b8caa23060f9a9cac092de685344)
- Update terraform and terraform-scaleway versions [ref commit](https://github.com/stefanprodan/k8s-scw-baremetal/pull/38/commits/b493901bc35982b41e5de1d4f600568d2899f750)
- Small typo fix on docs [ref commit](https://github.com/stefanprodan/k8s-scw-baremetal/pull/38/commits/0a665e00beda4bcc67101fb7110811c1242cfcbf)
- Fix for missing image in the kubernetes-dashboard [ref commit](https://github.com/stefanprodan/k8s-scw-baremetal/pull/38/commits/6dfc6759e79a276523411b2ebe05bba148f24c80), ref [issue](https://github.com/stefanprodan/k8s-scw-baremetal/issues/37)
- Add logging verbosity flag to kubeadm init [ref commit](https://github.com/stefanprodan/k8s-scw-baremetal/pull/38/commits/99c600337630ad9e893ff915acd875e42ebc1290)
- Bump default k8s_version to 1.12 [ref commit](https://github.com/stefanprodan/k8s-scw-baremetal/pull/38/commits/727199b22f1547bb48aced88da308f304be55e5c), I propose bumping to 1.13 when/if #34 is merged.


#### Testing carried out as follows:

***

***arch: arm***
***k8s_version: 1.13***

```bash
terraform apply  \
  -var region=par1 \
  -var arch=arm  \
  -var server_type=C1  \
  -var nodes=1  \
  -var server_type_node=C1  
  -var weave_passwd=ChangeMe \
  -var k8s_version=stable-1.13 \ 
  -var kubeadm_verbosity=4 \
  --auto-approve
```

```text
root@arm-master-1:~# kubectl get pods --all-namespaces
NAMESPACE     NAME                                    READY   STATUS    RESTARTS   AGE
kube-system   coredns-86c58d9df4-hwpmv                1/1     Running   0          73m
kube-system   coredns-86c58d9df4-jhtvr                1/1     Running   0          73m
kube-system   etcd-arm-master-1                       1/1     Running   0          72m
kube-system   heapster-674ff5566d-nv6fj               1/1     Running   0          72m
kube-system   kube-apiserver-arm-master-1             1/1     Running   0          72m
kube-system   kube-controller-manager-arm-master-1    1/1     Running   0          72m
kube-system   kube-proxy-57kxj                        1/1     Running   0          73m
kube-system   kube-proxy-6z66z                        1/1     Running   0          66m
kube-system   kube-scheduler-arm-master-1             1/1     Running   0          72m
kube-system   kubernetes-dashboard-7689cf4d74-gqn5q   1/1     Running   0          72m
kube-system   metrics-server-cd5f58b8-rqwj7           1/1     Running   0          72m
kube-system   weave-net-dgttl                         2/2     Running   0          73m
kube-system   weave-net-tf46m                         2/2     Running   0          66m
root@arm-master-1:~# kubectl get nodes -o wide
NAME           STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION          CONTAINER-RUNTIME
arm-master-1   Ready    master   73m   v1.13.1   <private>     <none>        Ubuntu 16.04.5 LTS   4.4.127-mainline-rev1   docker://17.3.0
arm-node-1     Ready    <none>   67m   v1.13.1   <private>   <none>        Ubuntu 16.04.5 LTS   4.4.127-mainline-rev1   docker://17.3.0
root@arm-master-1:~# 
```

***


***arch: arm***
***k8s_version: 1.12***

```bash
terraform apply  \
  -var region=par1 \
  -var arch=arm  \
  -var server_type=C1  \
  -var nodes=1  \
  -var server_type_node=C1  
  -var weave_passwd=ChangeMe \
  -var k8s_version=stable-1.12 \ 
  -var kubeadm_verbosity=4 \
  --auto-approve
```

```text
NAMESPACE     NAME                                   READY   STATUS    RESTARTS   AGE
kube-system   coredns-576cbf47c7-5ftdr               1/1     Running   0          9m28s
kube-system   coredns-576cbf47c7-vx2gv               1/1     Running   0          9m28s
kube-system   etcd-arm-master-1                      1/1     Running   0          8m30s
kube-system   heapster-97b5f7cc5-crmgg               1/1     Running   0          9m15s
kube-system   kube-apiserver-arm-master-1            1/1     Running   0          9m
kube-system   kube-controller-manager-arm-master-1   1/1     Running   0          8m49s
kube-system   kube-proxy-4vr9m                       1/1     Running   0          3m18s
kube-system   kube-proxy-b49j7                       1/1     Running   0          9m28s
kube-system   kube-scheduler-arm-master-1            1/1     Running   0          8m44s
kube-system   kubernetes-dashboard-86c855b57-c9pwq   1/1     Running   0          9m17s
kube-system   metrics-server-85984bff87-mvp4r        1/1     Running   0          9m12s
kube-system   weave-net-7rcq8                        2/2     Running   0          3m18s
kube-system   weave-net-vzf2x                        2/2     Running   0          9m27s

root@arm-master-1:~# kubectl get nodes -o wide
NAME           STATUS   ROLES    AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION          CONTAINER-RUNTIME
arm-master-1   Ready    master   8m22s   v1.12.4   <private>   <none>        Ubuntu 16.04.5 LTS   4.4.127-mainline-rev1   docker://17.3.0
arm-node-1     Ready    <none>   2m1s    v1.12.4   <private>   <none>        Ubuntu 16.04.5 LTS   4.4.127-mainline-rev1   docker://17.3.0
```

***

***arch: arm***
***k8s_version: 1.11***

```bash
terraform apply  \
  -var region=par1 \
  -var arch=arm  \
  -var server_type=C1  \
  -var nodes=1  \
  -var server_type_node=C1  
  -var weave_passwd=ChangeMe \
  -var k8s_version=stable-1.11 \ 
  -var kubeadm_verbosity=4 \
  --auto-approve
```


I can't post the results of running it on `1.11` and `arm` because sometimes scaleway takes a long time to start the nodes itself which is what is happening now.

I think `1.11` and `arm` will pass though once i can get the nodes to start. 
I'll post the results later.

@stefanprodan  I'm happy enough that this is ready to go.
