### PR TITLE
Easier terraform choice of docker and ubuntu versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ $ terraform apply \
  -var nodes=1 \
  -var server_type_node=C2S \
  -var weave_passwd=ChangeMe \
- -var docker_version=17.12.0~ce-0~ubuntu
+ -var docker_version=18.06 \
+ -var ubuntu_version="Ubuntu Bionic"
 ```
 
 This will do the following:
@@ -91,7 +92,8 @@ $ terraform apply \
  -var nodes=2 \
  -var server_type_node=C1 \
  -var weave_passwd=ChangeMe \
- -var docker_version=17.03.0~ce-0~ubuntu-xenial
+ -var docker_version=18.06 \
+ -var ubuntu_version="Ubuntu Xenial"
 ```
 
 ### Remote control

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ provider "external" {
   version = "1.0.0"
 }
 
-data "scaleway_image" "xenial" {
+data "scaleway_image" "ubuntu" {
   architecture = "${var.arch}"
-  name         = "Ubuntu Xenial"
+  name         = "${var.ubuntu_version}"
 }

--- a/master.tf
+++ b/master.tf
@@ -5,7 +5,7 @@ resource "scaleway_ip" "k8s_master_ip" {
 resource "scaleway_server" "k8s_master" {
   count          = 1
   name           = "${terraform.workspace}-master-${count.index + 1}"
-  image          = "${data.scaleway_image.xenial.id}"
+  image          = "${data.scaleway_image.ubuntu.id}"
   type           = "${var.server_type}"
   public_ip      = "${element(scaleway_ip.k8s_master_ip.*.ip, count.index)}"
   security_group = "${scaleway_security_group.master_security_group.id}"
@@ -36,8 +36,9 @@ set -e
 chmod +x /tmp/docker-install.sh
 chmod +x /tmp/kubeadm-install.sh
 
-/tmp/docker-install.sh ${var.docker_version} && \
-/tmp/kubeadm-install.sh ${var.k8s_version}
+export ubuntu_version=$(echo -n ${var.ubuntu_version} | cut -d " " -f 2 | awk '{print tolower($0)}')
+/tmp/docker-install.sh $${ubuntu_version} ${var.arch} ${var.docker_version} && \
+/tmp/kubeadm-install.sh ${var.k8s_version} && \
 
 modify_kube_apiserver_config(){
   while [[ ! -e /etc/kubernetes/manifests/kube-apiserver.yaml ]]; do

--- a/nodes.tf
+++ b/nodes.tf
@@ -5,7 +5,7 @@ resource "scaleway_ip" "k8s_node_ip" {
 resource "scaleway_server" "k8s_node" {
   count          = "${var.nodes}"
   name           = "${terraform.workspace}-node-${count.index + 1}"
-  image          = "${data.scaleway_image.xenial.id}"
+  image          = "${data.scaleway_image.ubuntu.id}"
   type           = "${var.server_type_node}"
   public_ip      = "${element(scaleway_ip.k8s_node_ip.*.ip, count.index)}"
   security_group = "${scaleway_security_group.node_security_group.id}"
@@ -31,7 +31,8 @@ resource "scaleway_server" "k8s_node" {
   provisioner "remote-exec" {
     inline = [
       "set -e",
-      "chmod +x /tmp/docker-install.sh && /tmp/docker-install.sh ${var.docker_version}",
+      "export ubuntu_version=$(echo -n ${var.ubuntu_version} | cut -d \" \" -f 2 | awk '{print tolower($0)}')",
+      "chmod +x /tmp/docker-install.sh && /tmp/docker-install.sh $${ubuntu_version} ${var.arch} ${var.docker_version}",
       "chmod +x /tmp/kubeadm-install.sh && /tmp/kubeadm-install.sh ${var.k8s_version}",
       "${data.external.kubeadm_join.result.command}",
     ]

--- a/scripts/docker-install.sh
+++ b/scripts/docker-install.sh
@@ -2,14 +2,28 @@
 
 set -e
 
-DOCKER_VERSION=$1
+UBUNTU_VERSION=$1
+ARCH=$2
+DOCKER_VERSION=$3
+
+if [[ ${ARCH} == "arm" ]]; then export ARCH=armhf; fi
+if [[ ${ARCH} == "x86_64" ]]; then export ARCH=amd64; fi
 
 apt-get update -qq
 apt-get install -y -qq apt-transport-https ca-certificates curl git
 curl -fsSL "https://download.docker.com/linux/ubuntu/gpg" | apt-key add -qq -
-echo "deb https://download.docker.com/linux/ubuntu xenial stable" | tee /etc/apt/sources.list.d/docker.list
+echo "deb [arch=${ARCH}] https://download.docker.com/linux/ubuntu ${UBUNTU_VERSION} stable" | \
+  tee /etc/apt/sources.list.d/docker.list
 apt-get update -qq
-apt-get install -y -qq --no-install-recommends docker-ce=${DOCKER_VERSION}
+
+if (( $(echo -n ${DOCKER_VERSION} | wc -c) > 5 )); then
+  export EXACT_DOCKER_VERSION=${DOCKER_VERSION}
+else
+  export EXACT_DOCKER_VERSION=$(apt-cache madison docker-ce | \
+    grep "${DOCKER_VERSION}.*${UBUNTU_VERSION}" | awk 'NR==1 {print $3}')
+fi
+
+apt-get install -y -qq --no-install-recommends docker-ce=${EXACT_DOCKER_VERSION}
 apt-mark hold docker-ce
 docker version
 

--- a/scripts/monitoring-install.sh
+++ b/scripts/monitoring-install.sh
@@ -15,7 +15,9 @@ if [ "$ARCH" == "arm" ]; then
     kubectl apply -f /tmp/heapster-arm.yaml;
     kubectl apply -f /tmp/metrics-server-arm.yaml;
 elif [ "$ARCH" == "x86_64" ]; then
-    kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/alternative/kubernetes-dashboard.yaml;
+    curl -s -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/alternative/kubernetes-dashboard.yaml | \
+    sed -e 's/v2.0.0-alpha0/v1.8.3/g' | \
+    kubectl apply -f -;
     kubectl apply -f /tmp/heapster-amd64.yaml;
     kubectl apply -f /tmp/metrics-server-amd64.yaml;
 fi

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,22 @@
+variable "ubuntu_version" {
+  default = "Ubuntu Xenial"
+  description = <<EOT
+
+For arm, choose from:
+  - Ubuntu Xenial
+
+For x86_64, choose from:
+  - Ubuntu Xenial
+  - Ubuntu Bionic
+
+Note: kubernetes only has xenial packages
+
+EOT
+}
+
 variable "docker_version" {
   default     = "17.03.0~ce-0~ubuntu-xenial"
-  description = "Use 17.12.0~ce-0~ubuntu for x86_64 and 17.03.0~ce-0~ubuntu-xenial for arm"
+  description = "Can be simple/non-specific with 5 characters (eg 18.06) or exact (eg 18.06.0~ce~3-0~ubuntu)"
 }
 
 variable "k8s_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "ubuntu_version" {
   description = <<EOT
 
 For arm, choose from:
-  - Ubuntu Xenial (recommended)
+  - Ubuntu Xenial
 
 For x86_64, choose from:
   - Ubuntu Xenial
@@ -11,13 +11,13 @@ For x86_64, choose from:
 
 Notes:
   - kubernetes only has xenial packages for debian
-  - currently arm is not working with ubuntu bionic (kubeadm init waiting issue)
+  - currently arm is not working with ubuntu bionic (kubeadm init hangs)
 
 EOT
 }
 
 variable "docker_version" {
-  default     = "17.03.0~ce-0~ubuntu-xenial"
+  default     = "18.06"
   description = <<EOT
 
 Specify the docker version either as

--- a/variables.tf
+++ b/variables.tf
@@ -3,20 +3,34 @@ variable "ubuntu_version" {
   description = <<EOT
 
 For arm, choose from:
-  - Ubuntu Xenial
+  - Ubuntu Xenial (recommended)
 
 For x86_64, choose from:
   - Ubuntu Xenial
   - Ubuntu Bionic
 
-Note: kubernetes only has xenial packages
+Notes:
+  - kubernetes only has xenial packages for debian
+  - currently arm is not working with ubuntu bionic (kubeadm init waiting issue)
 
 EOT
 }
 
 variable "docker_version" {
   default     = "17.03.0~ce-0~ubuntu-xenial"
-  description = "Can be simple/non-specific with 5 characters (eg 18.06) or exact (eg 18.06.0~ce~3-0~ubuntu)"
+  description = <<EOT
+
+Specify the docker version either as
+
+  - Simplified 5 characters name such as:
+    - 17.03
+    - 18.06
+
+  - The exact release name such as:
+    - 17.03.0~ce-0~ubuntu-xenial
+    - 18.06.0~ce~3-0~ubuntu
+
+EOT
 }
 
 variable "k8s_version" {


### PR DESCRIPTION
***Note:*** Pending merge of #38 in the first instance.

***What does this commit/MR/PR do?***
    
- Easier terraform choice of docker and ubuntu versions
- Allows Ubuntu Bionic Beaver and Xenial to be chosen as os
- Allows different docker image to be chosen for k8s cri
    
 ***Why is this commit/MR/PR needed?***
    
- More configurability in tf vars


### Testing carried out as follows:

***

***arch: arm***
***k8s_version: 1.12***
***os: Ubuntu Xenial***

```bash
terraform apply \
 -var region=par1 \
 -var arch=arm \
 -var server_type=C1 \
 -var nodes=1 \
 -var server_type_node=C1 \
 -var weave_passwd=ChangeMe \
 -var docker_version=18.06 \
 -var ubuntu_version="Ubuntu Xenial" \
 -var k8s_version=stable-1.12 \
 -var kubeadm_verbosity=4 \
 --auto-approve
```

```text
root@arm-master-1:~# kubectl get pods --all-namespaces
NAMESPACE     NAME                                   READY   STATUS    RESTARTS   AGE
kube-system   coredns-576cbf47c7-kndct               1/1     Running   0          21m
kube-system   coredns-576cbf47c7-m8j4g               1/1     Running   0          21m
kube-system   etcd-arm-master-1                      1/1     Running   0          20m
kube-system   heapster-97b5f7cc5-gd7tf               1/1     Running   0          21m
kube-system   kube-apiserver-arm-master-1            1/1     Running   0          20m
kube-system   kube-controller-manager-arm-master-1   1/1     Running   0          21m
kube-system   kube-proxy-lk6ql                       1/1     Running   0          14m
kube-system   kube-proxy-nfhxs                       1/1     Running   0          21m
kube-system   kube-scheduler-arm-master-1            1/1     Running   0          20m
kube-system   kubernetes-dashboard-86c855b57-r6krt   1/1     Running   0          21m
kube-system   metrics-server-85984bff87-cj9vg        1/1     Running   0          21m
kube-system   weave-net-j9qvr                        2/2     Running   0          14m
kube-system   weave-net-qn7f8                        2/2     Running   0          21m
NAME           STATUS   ROLES    AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION          CONTAINER-RUNTIME
arm-master-1   Ready    master   22m   v1.12.4   <private>   <none>        Ubuntu 16.04.5 LTS   4.4.127-mainline-rev1   docker://18.6.1
arm-node-1     Ready    <none>   15m   v1.12.4   <private>    <none>        Ubuntu 16.04.5 LTS   4.4.127-mainline-rev1   docker://18.6.1
```

***

***arch: arm***
***k8s_version: 1.12***
***os: Ubuntu Bionic***

```bash
terraform apply \
 -var region=par1 \
 -var arch=arm \
 -var server_type=C1 \
 -var nodes=1 \
 -var server_type_node=C1 \
 -var weave_passwd=ChangeMe \
 -var docker_version=18.06 \
 -var ubuntu_version="Ubuntu Bionic" \
 -var k8s_version=stable-1.12 \
 -var kubeadm_verbosity=4 \
 --auto-approve
```

This combination (***k8s 1.12, arm, Ubuntu Bionic***) fails due to the `kubernetes/kubeadm/issues/413` despite having a long `initialDelaySeconds`. Noted in the docs to that `Ubuntu Bionic` not working with arm - https://github.com/stefanprodan/k8s-scw-baremetal/pull/39/files#diff-c9ac8098c5ea9d3e6a9a596ff0c512a4R14.

```text
scaleway_server.k8s_master (remote-exec): [init] this might take a minute or longer if the control plane images have to be pulled
scaleway_server.k8s_master: Still creating... (18m50s elapsed)
scaleway_server.k8s_master: Still creating... (19m0s elapsed)
scaleway_server.k8s_master: Still creating... (19m10s elapsed)
scaleway_server.k8s_master: Still creating... (19m20s elapsed)
scaleway_server.k8s_master: Still creating... (19m30s elapsed)
scaleway_server.k8s_master: Still creating... (19m40s elapsed)
...
scaleway_server.k8s_master: Still creating... (24m30s elapsed)
scaleway_server.k8s_master: Still creating... (24m40s elapsed)
scaleway_server.k8s_master: Still creating... (24m50s elapsed)
scaleway_server.k8s_master: Still creating... (25m0s elapsed)
scaleway_server.k8s_master: Still creating... (25m10s elapsed)
```

***

***arch: x86_64***
***k8s_version: 1.12***
***os: Ubuntu Bionic***

```bash
terraform apply \
 -var region=par1 \
 -var arch=x86_64 \
 -var server_type=C2S \
 -var nodes=1 \
 -var server_type_node=C2S \
 -var weave_passwd=ChangeMe \
 -var docker_version=18.06 \
 -var ubuntu_version="Ubuntu Bionic" \
 -var k8s_version=stable-1.12 \
 -var kubeadm_verbosity=4 \
 --auto-approve
```

```text
root@amd-master-1:~# kubectl get pods --all-namespaces
NAMESPACE     NAME                                    READY   STATUS    RESTARTS   AGE
kube-system   coredns-576cbf47c7-jvwpt                1/1     Running   0          13m
kube-system   coredns-576cbf47c7-rcg9q                1/1     Running   0          13m
kube-system   etcd-amd-master-1                       1/1     Running   0          12m
kube-system   heapster-b79f64fd5-z6mdz                1/1     Running   0          13m
kube-system   kube-apiserver-amd-master-1             1/1     Running   0          12m
kube-system   kube-controller-manager-amd-master-1    1/1     Running   0          12m
kube-system   kube-proxy-765h7                        1/1     Running   0          7m23s
kube-system   kube-proxy-r9z7r                        1/1     Running   0          13m
kube-system   kube-scheduler-amd-master-1             1/1     Running   0          12m
kube-system   kubernetes-dashboard-5656f98747-5tq9j   1/1     Running   0          41s
kube-system   metrics-server-8449859949-wr9xs         1/1     Running   0          13m
kube-system   weave-net-45m4x                         2/2     Running   1          7m23s
kube-system   weave-net-bcgvv                         2/2     Running   0          13m
root@amd-master-1:~# kubectl get nodes -o wide
NAME           STATUS   ROLES    AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION         CONTAINER-RUNTIME
amd-master-1   Ready    master   13m     v1.12.4   <private>   <none>        Ubuntu 18.04.1 LTS   4.9.93-mainline-rev1   docker://18.6.1
amd-node-1     Ready    <none>   7m30s   v1.12.4   <private>   <none>        Ubuntu 18.04.1 LTS   4.9.93-mainline-rev1   docker://18.6.1
```