### PR TITLE
Introduce yaml files as config for kubeadm for v1.12+

### DIFF
--- a/kubeadm/v1alpha3-config.yaml
+++ b/kubeadm/v1alpha3-config.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: kubeadm.k8s.io/v1alpha3
+kind: InitConfiguration
+apiEndpoint:
+  advertiseAddress: CONFIG_CLUSTER_PRIVATE_IP
+  bindPort: 6443
+nodeRegistration:
+  kubeletExtraArgs:
+    "feature-gates": "BlockVolume=true,CRIContainerLogRotation=true"
+
+
+---
+apiVersion: kubeadm.k8s.io/v1alpha3
+kind: ClusterConfiguration
+kubernetesVersion: CONFIG_KUBERNETES_VERSION
+apiServerCertSANs:
+  - CONFIG_CLUSTER_PUBLIC_IP
+apiServerExtraArgs:
+  authorization-mode: Node,RBAC
+certificatesDir: /etc/kubernetes/pki
+clusterName: kubernetes
+imageRepository: k8s.gcr.io
+
+
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+containerLogMaxFiles: 1
+containerLogMaxSize: CONFIG_CONTAINER_LOG_MAX_SIZE
+maxPods: 110
+featureGates:
+  BlockVolume: true
+  CRIContainerLogRotation: true
+
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+
+
+# ---
+# apiVersion: kubeadm.k8s.io/v1alpha3
+# kind: JoinConfiguration
+

--- a/kubeadm/v1beta1-config.yaml
+++ b/kubeadm/v1beta1-config.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: CONFIG_CLUSTER_PRIVATE_IP
+  bindPort: 6443
+nodeRegistration:
+  kubeletExtraArgs:
+    "feature-gates": "BlockVolume=true,CRIContainerLogRotation=true"
+
+
+---
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+kubernetesVersion: CONFIG_KUBERNETES_VERSION
+apiServer:
+  extraArgs:
+    authorization-mode: Node,RBAC
+  certSANs:
+    - CONFIG_CLUSTER_PUBLIC_IP
+  timeoutForControlPlane: 4m0s
+controlPlaneEndpoint: CONFIG_CLUSTER_PRIVATE_IP:6443
+controllerManager:
+  extraArgs:
+    "node-cidr-mask-size": "20"
+scheduler:
+  extraArgs:
+    address: CONFIG_CLUSTER_PRIVATE_IP
+certificatesDir: /etc/kubernetes/pki
+imageRepository: k8s.gcr.io
+useHyperKubeImage: false
+
+
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+containerLogMaxFiles: 1
+containerLogMaxSize: CONFIG_CONTAINER_LOG_MAX_SIZE
+maxPods: 110
+featureGates:
+  BlockVolume: true
+  CRIContainerLogRotation: true
+
+
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+
+
+# ---
+# apiVersion: kubeadm.k8s.io/v1beta1
+# kind: JoinConfiguration

--- a/nodes.tf
+++ b/nodes.tf
@@ -10,11 +10,6 @@ resource "scaleway_server" "k8s_node" {
   public_ip      = "${element(scaleway_ip.k8s_node_ip.*.ip, count.index)}"
   security_group = "${scaleway_security_group.node_security_group.id}"
 
-  //  volume {
-  //    size_in_gb = 50
-  //    type       = "l_ssd"
-  //  }
-
   connection {
     type        = "ssh"
     user        = "root"

--- a/variables.tf
+++ b/variables.tf
@@ -77,6 +77,11 @@ variable "private_key" {
   description = "The path to your private key"
 }
 
+variable "container_log_max_size" {
+  default     = "100Mi"
+  description = "The maximum file size for container logs"
+}
+
 variable "kubeadm_verbosity" {
   default     = "0"
   description = "The verbosity level of the kubeadm init logs"

--- a/variables.tf
+++ b/variables.tf
@@ -34,7 +34,7 @@ EOT
 }
 
 variable "k8s_version" {
-  default = "stable-1.12"
+  default = "stable-1.13"
 }
 
 variable "weave_passwd" {
@@ -79,7 +79,7 @@ variable "private_key" {
 
 variable "container_log_max_size" {
   default     = "100Mi"
-  description = "The maximum file size for container logs"
+  description = "The maximum file size for container logs, k8s 1.12+ only"
 }
 
 variable "kubeadm_verbosity" {


### PR DESCRIPTION
***What does this commit/MR/PR do?***
    
- Introduce kubeadm.yaml as config for kubeadm
- Allow conditional installation of config depending on kubeadm version
- Remove redundant volume code blocks
- Bump k8s to version 1.13
- Add new `container_log_max_size` variable to limit max log files size
    
***Why is this commit/MR/PR needed?***
    
- Allow configuration the kubeadm installation via yaml file

This is a duplicate of #34 but with other pending PRs before it. It's cleaner this way.




### Testing carried out as follows:

***

***arch: x86_64***
***k8s_version: 1.12***
***os: Ubuntu Bionic***

```bash
terraform apply \
-var region=par1  \
-var arch=x86_64  \
-var server_type=C2S  \
-var nodes=1  \
-var server_type_node=C2S \
-var weave_passwd=ChangeMe  \
-var docker_version=18.06 \
-var ubuntu_version="Ubuntu Bionic"  \
-var k8s_version=stable-1.12 \
-var kubeadm_verbosity=4  \
--auto-approve;
```

```text
NAMESPACE     NAME                                    READY   STATUS    RESTARTS   AGE
kube-system   coredns-576cbf47c7-9x94x                1/1     Running   0          7m10s
kube-system   coredns-576cbf47c7-wpcxb                1/1     Running   0          7m10s
kube-system   etcd-amd-master-1                       1/1     Running   0          6m18s
kube-system   heapster-b79f64fd5-8c2s5                1/1     Running   0          7m10s
kube-system   kube-apiserver-amd-master-1             1/1     Running   0          6m27s
kube-system   kube-controller-manager-amd-master-1    1/1     Running   0          6m27s
kube-system   kube-proxy-dn646                        1/1     Running   0          7m10s
kube-system   kube-proxy-lm5xz                        1/1     Running   0          2m15s
kube-system   kube-scheduler-amd-master-1             1/1     Running   0          6m42s
kube-system   kubernetes-dashboard-5656f98747-jd7pk   1/1     Running   0          7m10s
kube-system   metrics-server-8449859949-2nmcz         1/1     Running   0          7m9s
kube-system   weave-net-4vgnr                         2/2     Running   0          7m10s
kube-system   weave-net-699zt                         2/2     Running   1          2m15s
root@amd-master-1:~# kubectl get nodes -o wide
NAME           STATUS   ROLES    AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION         CONTAINER-RUNTIME
amd-master-1   Ready    master   7m27s   v1.12.4   <private>   <none>        Ubuntu 18.04.1 LTS   4.9.93-mainline-rev1   docker://18.6.1
amd-node-1     Ready    <none>   2m22s   v1.12.4   <private>   <none>        Ubuntu 18.04.1 LTS   4.9.93-mainline-rev1   docker://18.6.1
```

***

***arch: x86_64***
***k8s_version: 1.13***
***os: Ubuntu Bionic***

```bash
terraform apply \
-var region=par1  \
-var arch=x86_64  \
-var server_type=C2S  \
-var nodes=1  \
-var server_type_node=C2S \
-var weave_passwd=ChangeMe  \
-var docker_version=18.06 \
-var ubuntu_version="Ubuntu Bionic"  \
-var k8s_version=stable-1.13 \
-var kubeadm_verbosity=4  \
--auto-approve;
```

```text
root@amd-master-1:~# kubectl get pods --all-namespaces
NAMESPACE     NAME                                   READY   STATUS    RESTARTS   AGE
kube-system   coredns-86c58d9df4-khwp6               1/1     Running   0          5m32s
kube-system   coredns-86c58d9df4-knwhj               1/1     Running   0          5m32s
kube-system   etcd-amd-master-1                      1/1     Running   0          4m58s
kube-system   heapster-85567884db-8fxpk              1/1     Running   0          5m32s
kube-system   kube-apiserver-amd-master-1            1/1     Running   0          4m37s
kube-system   kube-controller-manager-amd-master-1   1/1     Running   0          4m35s
kube-system   kube-proxy-dwdh8                       1/1     Running   0          5m32s
kube-system   kube-proxy-zmwz8                       1/1     Running   0          69s
kube-system   kube-scheduler-amd-master-1            1/1     Running   0          4m55s
kube-system   kubernetes-dashboard-7ddfcf8dd-j4ph9   1/1     Running   0          5m32s
kube-system   metrics-server-85cbdf565d-5blh9        1/1     Running   0          5m32s
kube-system   weave-net-82tvt                        2/2     Running   0          5m32s
kube-system   weave-net-9r7mf                        2/2     Running   1          69s
root@amd-master-1:~# kubectl get nodes -o wide
NAME           STATUS   ROLES    AGE     VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION         CONTAINER-RUNTIME
amd-master-1   Ready    master   5m48s   v1.13.1   <private>   <none>        Ubuntu 18.04.1 LTS   4.9.93-mainline-rev1   docker://18.6.1
amd-node-1     Ready    <none>   74s     v1.13.1   <private>   <none>        Ubuntu 18.04.1 LTS   4.9.93-mainline-rev1   docker://18.6.1
```


***

***arch: arm***
***k8s_version: 1.13***
***os: Ubuntu Xenial***

```bash
terraform apply \
  -var region=par1  \
  -var arch=arm  \
  -var server_type=C1  \
  -var nodes=1  \
  -var server_type_node=C1 \
  -var weave_passwd=ChangeMe  \
  -var docker_version=18.06 \
  -var ubuntu_version="Ubuntu Xenial"  \
  -var k8s_version=stable-1.13 \
  -var kubeadm_verbosity=4  \
  --auto-approve;
```


```text
root@arm-master-1:~# kubectl get pods --all-namespaces
NAMESPACE     NAME                                    READY   STATUS    RESTARTS   AGE
kube-system   coredns-86c58d9df4-nrjkf                1/1     Running   0          10m
kube-system   coredns-86c58d9df4-wj6xf                1/1     Running   0          10m
kube-system   etcd-arm-master-1                       1/1     Running   0          9m35s
kube-system   heapster-674ff5566d-lbqdz               1/1     Running   0          9m55s
kube-system   kube-apiserver-arm-master-1             1/1     Running   0          9m8s
kube-system   kube-controller-manager-arm-master-1    1/1     Running   0          9m26s
kube-system   kube-proxy-5cspp                        1/1     Running   0          10m
kube-system   kube-proxy-s8rtx                        1/1     Running   0          4m9s
kube-system   kube-scheduler-arm-master-1             1/1     Running   0          9m37s
kube-system   kubernetes-dashboard-7689cf4d74-qnrs7   1/1     Running   0          9m57s
kube-system   metrics-server-cd5f58b8-shrr5           1/1     Running   0          9m52s
kube-system   weave-net-rp2j4                         2/2     Running   1          4m9s
kube-system   weave-net-sd552                         2/2     Running   0          10m
root@arm-master-1:~# kubectl get nodes -o wide
NAME           STATUS   ROLES    AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION          CONTAINER-RUNTIME
arm-master-1   Ready    master   10m     v1.13.1   <private>   <none>        Ubuntu 16.04.5 LTS   4.4.127-mainline-rev1   docker://18.6.1
arm-node-1     Ready    <none>   4m16s   v1.13.1   <private>     <none>        Ubuntu 16.04.5 LTS   4.4.127-mainline-rev1   docker://18.6.1
```

***