### PR TITLE
Put authorization mode value in quotes

### DIFF
--- a/kubeadm/v1alpha3-config.yaml
+++ b/kubeadm/v1alpha3-config.yaml
@@ -16,7 +16,7 @@ kubernetesVersion: CONFIG_KUBERNETES_VERSION
 apiServerCertSANs:
   - CONFIG_CLUSTER_PUBLIC_IP
 apiServerExtraArgs:
-  authorization-mode: Node,RBAC
+  authorization-mode: "Node,RBAC"
 certificatesDir: /etc/kubernetes/pki
 clusterName: kubernetes
 imageRepository: k8s.gcr.io

--- a/kubeadm/v1beta1-config.yaml
+++ b/kubeadm/v1beta1-config.yaml
@@ -15,7 +15,7 @@ kind: ClusterConfiguration
 kubernetesVersion: CONFIG_KUBERNETES_VERSION
 apiServer:
   extraArgs:
-    authorization-mode: Node,RBAC
+    authorization-mode: "Node,RBAC"
   certSANs:
     - CONFIG_CLUSTER_PUBLIC_IP
   timeoutForControlPlane: 4m0s


### PR DESCRIPTION
What does this commit/MR/PR do?

- Put authorization mode value in quotes

Why is this commit/MR/PR needed?

- The docs have it this way
- Ref:
https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha3