### PR TITLE
Added support for KUBELET_EXTRA_ARGS

### DIFF
--- a/nodes.tf
+++ b/nodes.tf
@@ -29,6 +29,7 @@ resource "scaleway_server" "k8s_node" {
       "export ubuntu_version=$(echo -n ${var.ubuntu_version} | cut -d \" \" -f 2 | awk '{print tolower($0)}')",
       "chmod +x /tmp/docker-install.sh && /tmp/docker-install.sh $${ubuntu_version} ${var.arch} ${var.docker_version}",
       "chmod +x /tmp/kubeadm-install.sh && /tmp/kubeadm-install.sh ${var.k8s_version}",
+      "echo 'KUBELET_EXTRA_ARGS=${var.kubelet_extra_args}' > /etc/default/kubelet",
       "${data.external.kubeadm_join.result.command}",
     ]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -87,3 +87,7 @@ variable "kubeadm_verbosity" {
   description = "The verbosity level of the kubeadm init logs"
 }
 
+variable "kubelet_extra_args" {
+  default = ""
+  description = "Extra arguments used by kubelet systemd"
+}


### PR DESCRIPTION
This patch adds support for KUBELET_EXTRA_ARGS, which enables you to set certain parameters **before** joining node to the cluster. 

I.e. in my case I needed to have several types of nodes created (for example 2 nodes with traefik on them and 10 with only php backend) and to be able to scale them separately without tagging individual nodes by hand. 

i.e. `-var kubelet_extra_args="--node-labels=node-type=default"`